### PR TITLE
Nomutablemodel

### DIFF
--- a/InteractModels/src/interactive.jl
+++ b/InteractModels/src/interactive.jl
@@ -63,7 +63,7 @@ ui = InteractModel(model; grouped=false, throttle=0.1) do m
 end
 ```
 """
-mutable struct InteractModel{F,L,Ti,Th} <: MutableModel
+mutable struct InteractModel{F,L,Ti,Th} <: AbstractModel
     f::F
     parent::Any
     grouped::Bool
@@ -105,8 +105,8 @@ end
 
 
 """
-    attach_sliders!(f, model::MutableModel; grouped=false, throttle=0.1)
-    attach_sliders!(model::MutableModel; grouped=false, throttle=0.1, f=identity)
+    attach_sliders!(f, model::AbstractModel; grouped=false, throttle=0.1)
+    attach_sliders!(model::AbstractModel; grouped=false, throttle=0.1, f=identity)
 
 Internal method that may be useful for creating custom interfaces like `InteractModel`,
 without actually using `InteracModel` directly. This interface will be less stable than
@@ -118,7 +118,7 @@ Create sliders and attach them to the model so it will be updated when they are 
 
 - `f`: a function that accepts the model, stripped of `Param` wrappers, with a return value
   that sets the observable `obs`. Usually this converts it to a plot or other web output.
-- `model`: a [`MutableModel`](@ref)
+- `model`: a [`AbstractModel`](@ref)
 
 ## Keyword Arguments
 - `throttle`: `0.1` - sliders response time, in seconds.

--- a/InteractModels/test/runtests.jl
+++ b/InteractModels/test/runtests.jl
@@ -9,13 +9,13 @@ using InteractModels, DataFrames, Interact, Test
     ]
     width, height = 700, 300
     nsamples = 256
-    params = (;
+    pars = (;
         sample_step=Param(val=0.05, range=0.01:0.001:0.1, label="Sample step", description="The step size between samples"),
         phase=Param(val=0.0, range=0:0.1:2pi, label="Phase", description="Phase of the starting point"),
         radii=Param(val=20,range=0:0.1:60, label="Radus", description="Radius of the circles")
     )
 
-    interface = InteractModel(params; grouped=false, title="slinky") do m
+    interface = InteractModel(pars; grouped=false, title="slinky") do m
         m = stripparams(m)
         println(m)
         cxs_unscaled = [i * m.sample_step + m.phase for i in 1:nsamples]
@@ -34,9 +34,9 @@ using InteractModels, DataFrames, Interact, Test
     # TODO how to test this more?
     
     # To test manually
-    # using Blink
-    # w = Blink.Window()
-    # body!(w, interface)
+    using Blink
+    w = Blink.Window()
+    body!(w, interface)
 
     @testset "Test the tables interface and getproperty work on InteractModel too" begin
         df = DataFrame(interface)

--- a/InteractModels/test/runtests.jl
+++ b/InteractModels/test/runtests.jl
@@ -34,9 +34,9 @@ using InteractModels, DataFrames, Interact, Test
     # TODO how to test this more?
     
     # To test manually
-    using Blink
-    w = Blink.Window()
-    body!(w, interface)
+    # using Blink
+    # w = Blink.Window()
+    # body!(w, interface)
 
     @testset "Test the tables interface and getproperty work on InteractModel too" begin
         df = DataFrame(interface)

--- a/src/ModelParameters.jl
+++ b/src/ModelParameters.jl
@@ -14,7 +14,7 @@ import AbstractNumbers,
 
 using Setfield
       
-export AbstractModel, MutableModel, Model, StaticModel
+export AbstractModel, Model, StaticModel
 
 export AbstractParam, Param
 

--- a/src/model.jl
+++ b/src/model.jl
@@ -134,7 +134,7 @@ _keys(params::Tuple{}, m::AbstractModel) = ()
     end
 end
 
-function Base.show(io::IO, m::AbstractModel)
+function Base.show(io::IO, ::MIME"text/plain", m::AbstractModel)
     show(typeof(m))
     println(io, " with parent object of type: \n")
     show(typeof(parent(m)))

--- a/src/param.jl
+++ b/src/param.jl
@@ -9,6 +9,7 @@ constructor that accepts a `NamedTuple`. It must have a `val` property, and shou
 `checkhasval` in its constructor.
 """
 abstract type AbstractParam{T} <: AbstractNumbers.AbstractNumber{T} end
+
 @inline withunits(m, args...) = map(p -> withunits(p, args...), params(m))
 @inline function withunits(p::AbstractParam, fn::Symbol=:val)
     _applyunits(*, getproperty(p, fn), get(p, :units, nothing))
@@ -45,6 +46,9 @@ AbstractNumbers.number(p::AbstractParam) = withunits(p)
 AbstractNumbers.basetype(::Type{<:AbstractParam{T}}) where T = T
 AbstractNumbers.like(::Type{<:AbstractParam}, x) = x
 
+# Flatten.jl defaults defined here: AbstractParam needs to be defined first
+const SELECT = AbstractParam
+const IGNORE = AbstractArray
 
 # Concrete implementation
 
@@ -73,8 +77,8 @@ Param(; kwargs...) = Param((; kwargs...))
 Base.parent(p::Param) = getfield(p, :parent)
 
 # Methods for objects that hold params
-params(x) = Flatten.flatten(x, AbstractParam)
-stripparams(x) = hasparam(x) ? Flatten.reconstruct(x, withunits(x), AbstractParam) : x
+params(x) = Flatten.flatten(x, SELECT, IGNORE)
+stripparams(x) = hasparam(x) ? Flatten.reconstruct(x, withunits(x), SELECT, IGNORE) : x
 
 
 # Utils

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -98,12 +98,12 @@ end
         Union{Nothing,Tuple{Float64,Float64}},
     )
     df = DataFrame(m)
-    @test all(df.component .== m[:component])
-    @test all(df.fieldname .== m[:fieldname])
-    @test all(df.val .== m[:val])
-    @test all(df.bounds .== m[:bounds])
+    @test all(df.component .== m.component)
+    @test all(df.fieldname .== m.fieldname)
+    @test all(df.val .== m.val)
+    @test all(df.bounds .== m.bounds)
 
-    df[:val] .*= 3
+    df.val .*= 3
     ModelParameters.update!(m, df)
     @test m[:val] == (3.0, 6.0, 9.0, 12.0, 15.0, 18.0, 297, 300.0)
 end


### PR DESCRIPTION
Remove the abstract type `MuitableModel` so all models just inherit from `AbstractModel`

Also ignores all Array in Flatten.jl methods.