### PR TITLE
sliders in columns with ncolumns or auto

### DIFF
--- a/InteractModels/test/runtests.jl
+++ b/InteractModels/test/runtests.jl
@@ -15,7 +15,7 @@ using InteractModels, DataFrames, Interact, Test
         radii=Param(val=20,range=0:0.1:60, label="Radus", description="Radius of the circles")
     )
 
-    interface = InteractModel(pars; grouped=false, title="slinky") do m
+    interface = InteractModel(pars; ncolumns=2, grouped=false, title="slinky") do m
         m = stripparams(m)
         println(m)
         cxs_unscaled = [i * m.sample_step + m.phase for i in 1:nsamples]


### PR DESCRIPTION
@virgile-baudrot this is where all the sliders are handled - fixing them here fixes them for GrowthMaps.jl as well, and any other package that uses ModelParameters.jl.

You can probably check this out and see if it works. It will just make the columns automatically, I'll need to update the other package to do it manually