### PR TITLE
group sliders based on a submodel type

### DIFF
--- a/InteractModels/src/InteractModels.jl
+++ b/InteractModels/src/InteractModels.jl
@@ -11,6 +11,8 @@ using Interact,
 
 @reexport using ModelParameters
 
+using ModelParameters.Flatten
+
 export InteractModel, ui
 
 include("interactive.jl")

--- a/InteractModels/test/runtests.jl
+++ b/InteractModels/test/runtests.jl
@@ -15,7 +15,7 @@ using InteractModels, DataFrames, Interact, Test
         radii=Param(val=20,range=0:0.1:60, label="Radus", description="Radius of the circles")
     )
 
-    interface = InteractModel(pars; ncolumns=2, grouped=false, title="slinky") do m
+    interface = InteractModel(pars; ncolumns=2, title="slinky") do m
         m = stripparams(m)
         println(m)
         cxs_unscaled = [i * m.sample_step + m.phase for i in 1:nsamples]
@@ -32,11 +32,31 @@ using InteractModels, DataFrames, Interact, Test
     # Title node matches.
     @test first(ui_.children).children == dom"h1"("slinky").children
     # TODO how to test this more?
+
+    submodel_interface = InteractModel(pars; ncolumns=2, submodel=NamedTuple, title="slinky") do m
+        m = stripparams(m)
+        println(m)
+        cxs_unscaled = [i * m.sample_step + m.phase for i in 1:nsamples]
+        cys = sin.(cxs_unscaled) .* height/3 .+ height/2
+        cxs = cxs_unscaled .* width/4pi
+        # dom"div"()
+        dom"svg:svg[width=$width, height=$height]"(
+             (dom"svg:circle[cx=$(cxs[i]), cy=$(cys[i]), r=$(m.radii), fill=$(color(i))]"()
+              for i in 1:nsamples)...
+        )
+    end
+
+    ui_ = ui(submodel_interface)
+    @test first(ui_.children).children == dom"h1"("slinky").children
+    # We can find the group name
+    @test ui_.children[3].children[1].children[1].children[1].children == dom"h2"("NamedTuple").children
+
     
     # To test manually
     # using Blink
     # w = Blink.Window()
     # body!(w, interface)
+    # body!(w, submodel_interface)
 
     @testset "Test the tables interface and getproperty work on InteractModel too" begin
         df = DataFrame(interface)


### PR DESCRIPTION
This improves submodel grouping by instead of automatically using the parent object to group sliders, ti allows specifying a type or Union of types that are submodels. E.g. for DynamicGrids.jl this is `Rule`.