### PR TITLE
dont override setproperty or getproperty

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,14 +76,14 @@ And parameters:
 │ Submodel2 │     γ │ 0.001 │ (0.0001, 0.01) │
 └───────────┴───────┴───────┴────────────────┘
 
-julia> model.val
+julia> model[:val]
 (0.8, 0.5, 0.8, 0.001)
 ```
 
 To get the model values as a vector for Optim.jl, simply:
 
 ```julia
-collect(model.val)
+collect(model[:val])
 ```
 
 ## What are Params?
@@ -138,7 +138,7 @@ model parameter changes you make with the generated sliders.
 You can also add new columns to all model parameters directly from the model:
 
 ```julia
-model.bounds = ((1.0, 4.0), (0.0, 1.0), (0.0, 0.1), (0.0, 100.0))
+model[:bounds] = ((1.0, 4.0), (0.0, 1.0), (0.0, 0.1), (0.0, 100.0))
 ```
 
 ### Swapping number types
@@ -147,7 +147,7 @@ ModelParameters makes it very easy to make modifications to your model
 parameters. To update all model values to be `Float32`, you can simply do: 
 
 ```julia
-model.val = map(Float32, model.val)
+model[:val] = map(Float32, model[:val])
 ```
 
 ## Tables.jl interface

--- a/src/model.jl
+++ b/src/model.jl
@@ -220,8 +220,6 @@ mutable struct Model <: AbstractModel
 end
 Model(m::AbstractModel) = Model(parent(m))
 
-Base.getproperty(m::Model, key::Symbol) = getindex(m, key::Symbol)
-Base.setproperty!(m::Model, key::Symbol, x) = setindex!(m, x, key::Symbol)
 
 update(x, values::AbstractVector) = update(x, Tuple(values))
 function update(x, values)
@@ -252,9 +250,6 @@ struct StaticModel{P} <: AbstractModel
     end
 end
 StaticModel(m::AbstractModel) = StaticModel(parent(m))
-
-Base.getproperty(m::StaticModel, key::Symbol) = getindex(m, key::Symbol)
-Base.setproperty!(m::StaticModel, key::Symbol, x) = setindex!(m, x, key::Symbol)
 
 # Model Utils
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -64,19 +64,19 @@ end
 
 @testset "getproperties returns column tuples of param fields" begin
     m = Model(s1)
-    @test m.component === m[:component] === (S1, S1, S1, S1, Tuple, Tuple, S2, S2)
-    @test m.fieldname === m[:fieldname] === (:a, :b, :c, :d, 1, 2, :h, :j)
-    @test m.val === m[:val] === (1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 99, 100.0)
-    @test m.bounds === m[:bounds] === ((5.0, 15.0), (5.0, 15.0), (5.0, 15.0), nothing,
+    @test m[:component] === (S1, S1, S1, S1, Tuple, Tuple, S2, S2)
+    @test m[:fieldname] === (:a, :b, :c, :d, 1, 2, :h, :j)
+    @test m[:val] === (1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 99, 100.0)
+    @test m[:bounds] === ((5.0, 15.0), (5.0, 15.0), (5.0, 15.0), nothing,
                        (5.0, 15.0), (5.0, 15.0), nothing, (50.0, 150.0))
 end
 
-@testset "setproperties updates and adds param fields" begin
+@testset "setindex updates and adds param fields" begin
     m = Model(s1)
     m[:val] = m[:val] .* 2
     @test m[:val] == (2.0, 4.0, 6.0, 8.0, 10.0, 12.0, 198, 200.0)
-    m.newfield = ntuple(x -> x, 8)
-    @test m.newfield == m[:newfield] == ntuple(x -> x, 8)
+    m[:newfield] = ntuple(x -> x, 8)
+    @test m[:newfield] == ntuple(x -> x, 8)
 end
 
 @testset "strip params from model" begin
@@ -98,10 +98,10 @@ end
         Union{Nothing,Tuple{Float64,Float64}},
     )
     df = DataFrame(m)
-    @test all(df.component .== m.component)
-    @test all(df.fieldname .== m.fieldname)
-    @test all(df.val .== m.val)
-    @test all(df.bounds .== m.bounds)
+    @test all(df.component .== m[:component])
+    @test all(df.fieldname .== m[:fieldname])
+    @test all(df.val .== m[:val])
+    @test all(df.bounds .== m[:bounds])
 
     df.val .*= 3
     ModelParameters.update!(m, df)


### PR DESCRIPTION
Especially seeing this package is based on ConstructionBase.jl, overriding `getproperty`and `setproperty` suggests the object can be rebuilt from these values. It can't, and it will break use of Setfield.jl etc. So instead, we just use getindex. `model[:val]`. Its not as clean, but fine.