### PR TITLE
models without sliders still work

### DIFF
--- a/InteractModels/test/runtests.jl
+++ b/InteractModels/test/runtests.jl
@@ -68,10 +68,10 @@ using InteractModels, DataFrames, Interact, Test
 end
 
 @testset "empty models still work" begin
-    InteractModel((; named=:tuple, without=:params); ncolumns=2) do m
+    InteractModel((named=:tuple, without=:params); ncolumns=2) do m
         hbox()
     end
-    InteractModel((; p1=Param(1), p2=Param(2)); submodel=Tuple, ncolumns=2) do m
+    InteractModel((p1=Param(1), p2=Param(2)); submodel=Tuple, ncolumns=2) do m
         hbox()
     end
 end

--- a/InteractModels/test/runtests.jl
+++ b/InteractModels/test/runtests.jl
@@ -66,3 +66,12 @@ using InteractModels, DataFrames, Interact, Test
     end
 
 end
+
+@testset "empty models still work" begin
+    InteractModel((; named=:tuple, without=:params); ncolumns=2) do m
+        hbox()
+    end
+    InteractModel((; p1=Param(1), p2=Param(2)); submodel=Tuple, ncolumns=2) do m
+        hbox()
+    end
+end


### PR DESCRIPTION
Fix InteractModel interface so there are no errors, when there are either no Params in the model at all, or none inside a specified submodel type. The interface just has no sliders, as you would expect.