### PR TITLE
Fix non-mutating update unnecessarily allocating

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ authors = ["Rafael Schouten <rafaelschouten@gmail.com> and contributors"]
 version = "0.3.2"
 
 [deps]
-
 AbstractNumbers = "85c772de-338a-5e7f-b815-41e76c26ac1f"
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
 ConstructionBaseExtras = "914cd950-b775-4282-9f32-54fc4544c321"
@@ -17,7 +16,6 @@ Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 AbstractNumbers = "0.2.1"
 ConstructionBase = "1"
 ConstructionBaseExtras = "0.1"
-Flatten = "0.4"
 PrettyTables = "0.8, 0.9, 0.10, 0.11, 0.12, 1"
 Setfield = "0.6, 0.7"
 Tables = "1"
@@ -25,10 +23,11 @@ julia = "1"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [targets]
-test = ["Aqua", "DataFrames", "StaticArrays", "Test", "Unitful"]
+test = ["Aqua", "BenchmarkTools", "DataFrames", "StaticArrays", "Test", "Unitful"]


### PR DESCRIPTION
This PR requires rafaqz/Flatten.jl#29 to make Flatten.reconstruct type stable.

Resolves #25