### PR TITLE
Add function for restructuring params into nested groups

### DIFF
--- a/src/ModelParameters.jl
+++ b/src/ModelParameters.jl
@@ -19,7 +19,7 @@ export AbstractModel, Model, StaticModel
 
 export AbstractParam, Param
 
-export params, printparams, stripparams, update, update!, withunits, stripunits, group, flat
+export params, printparams, stripparams, update, update!, withunits, stripunits, groupparams, mapflat
 
 include("interface.jl")
 include("param.jl")

--- a/src/ModelParameters.jl
+++ b/src/ModelParameters.jl
@@ -19,7 +19,7 @@ export AbstractModel, Model, StaticModel
 
 export AbstractParam, Param
 
-export params, printparams, stripparams, update, update!, withunits, stripunits
+export params, printparams, stripparams, update, update!, withunits, stripunits, group, flat
 
 include("interface.jl")
 include("param.jl")

--- a/src/model.jl
+++ b/src/model.jl
@@ -298,7 +298,7 @@ For example, we could group parameters first by component name, then by field na
 
 # Examples
 ```julia-repl
-julia> group(Model((a=Param(1.0), b=Param(2.0))), :component, :fieldname)
+julia> groupparams(Model((a=Param(1.0), b=Param(2.0))), :component, :fieldname)
 (NamedTuple = (a = ..., b = ...),)
 ```
 """

--- a/src/tables.jl
+++ b/src/tables.jl
@@ -19,4 +19,4 @@ Tables.getcolumn(m::AbstractModel, ::Type{T}, col::Int, nm::Symbol) where T =
 Tables.rowaccess(::Type{<:AbstractModel}) = true
 # Vector of NamedTuple already has a row interface defined,
 # so we take a shortcut and return that.
-Tables.rows(m::AbstractModel) = [nt for nt in map(fields, params(m))]
+Tables.rows(m::AbstractModel) = [nt for nt in map((p,typ,name) -> merge((component=typ,fieldname=name), parent(p)), params(m), paramparenttypes(m), paramfieldnames(m))]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -193,13 +193,13 @@ end
         Param(8.0, group=:B),
     )
     m = Model(s2)
-    # group
-    groupedparams = group(m, :group)
+    # groupparams
+    groupedparams = groupparams(m, :group)
     @test haskey(groupedparams, :A)
     @test length(groupedparams.A) == 4
     @test haskey(groupedparams, :B)
     @test length(groupedparams.B) == 4
-    groupedparams = group(m, :group, :fieldname)
+    groupedparams = groupparams(m, :group, :fieldname)
     @test haskey(groupedparams, :A)
     @test haskey(groupedparams, :B)
     @test groupedparams.A.a == [s1.a]
@@ -211,7 +211,7 @@ end
     @test groupedparams.A.i == [s2.i]
     @test groupedparams.B.j == [s2.j]
     # flat
-    groupedvals = map(flat(p -> p.val), groupedparams)
+    groupedvals = mapflat(p -> p.val, groupedparams)
     @test groupedvals.A.a == [s1.a.val]
     @test groupedvals.A.b == [s1.b.val]
     @test groupedvals.A.c == [s1.c.val]
@@ -220,8 +220,8 @@ end
     @test groupedvals.B.f == [s1.f.val]
     @test groupedvals.A.i == [s2.i.val]
     @test groupedvals.B.j == [s2.j.val]
-    # convert to tuples; uses matchtype kwarg to recurse only on NamedTuples, not arrays
-    tuplegroups = map(flat(Tuple, matchtype=NamedTuple), groupedparams)
+    # convert to tuples; uses maptype kwarg to recurse exclusively on NamedTuples, not arrays
+    tuplegroups = mapflat(Tuple, groupedparams; maptype=NamedTuple)
     @test isa(tuplegroups.A.a, Tuple)
     @test isa(tuplegroups.A.b, Tuple)
     @test isa(tuplegroups.A.c, Tuple)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -177,3 +177,57 @@ end
     b = BenchmarkTools.@benchmark update($s2, $ps)
     @test b.allocs == 0
 end
+
+@testset "parameter grouping" begin
+    s1 = S1(
+       Param(1.0; bounds=(5.0, 15.0), group=:A),
+       Param(2.0; bounds=(5.0, 15.0), units=u"s", group=:A),
+       Param(3.0; bounds=(5.0, 15.0), units=u"K", group=:A),
+       Param(4.0; units=u"m", group=:B),
+       Param(5.0; bounds=(5.0, 15.0), group=:B),
+       Param(6.0, group=:B),
+    )
+    s2 = S2(
+        s1,
+        Param(7.0; bounds=(50.0, 150.0), units=u"m*s^2", group=:A),
+        Param(8.0, group=:B),
+    )
+    m = Model(s2)
+    # group
+    groupedparams = group(m, :group)
+    @test haskey(groupedparams, :A)
+    @test length(groupedparams.A) == 4
+    @test haskey(groupedparams, :B)
+    @test length(groupedparams.B) == 4
+    groupedparams = group(m, :group, :fieldname)
+    @test haskey(groupedparams, :A)
+    @test haskey(groupedparams, :B)
+    @test groupedparams.A.a == [s1.a]
+    @test groupedparams.A.b == [s1.b]
+    @test groupedparams.A.c == [s1.c]
+    @test groupedparams.B.d == [s1.d]
+    @test groupedparams.B.e == [s1.e]
+    @test groupedparams.B.f == [s1.f]
+    @test groupedparams.A.i == [s2.i]
+    @test groupedparams.B.j == [s2.j]
+    # flat
+    groupedvals = map(flat(p -> p.val), groupedparams)
+    @test groupedvals.A.a == [s1.a.val]
+    @test groupedvals.A.b == [s1.b.val]
+    @test groupedvals.A.c == [s1.c.val]
+    @test groupedvals.B.d == [s1.d.val]
+    @test groupedvals.B.e == [s1.e.val]
+    @test groupedvals.B.f == [s1.f.val]
+    @test groupedvals.A.i == [s2.i.val]
+    @test groupedvals.B.j == [s2.j.val]
+    # convert to tuples; uses matchtype kwarg to recurse only on NamedTuples, not arrays
+    tuplegroups = map(flat(Tuple, matchtype=NamedTuple), groupedparams)
+    @test isa(tuplegroups.A.a, Tuple)
+    @test isa(tuplegroups.A.b, Tuple)
+    @test isa(tuplegroups.A.c, Tuple)
+    @test isa(tuplegroups.B.d, Tuple)
+    @test isa(tuplegroups.B.e, Tuple)
+    @test isa(tuplegroups.B.f, Tuple)
+    @test isa(tuplegroups.A.i, Tuple)
+    @test isa(tuplegroups.B.j, Tuple)
+end


### PR DESCRIPTION
I would like to be able to easily turn `ModelParameters` param tables into [ComponentArrays](https://github.com/jonniedie/ComponentArrays.jl), and I figured the easiest way to do this was by just first turning it into a nested `NamedTuple`. I suspect this will be useful for other users of `ModelParameters` so why not just include it in the package?

The purpose of the `flat` function is to allow one to write:

```
vals = map(flat(p -> p.val), group(model, :component, :fieldname))
carr = ComponentArray(vals)
```

`flat` simply wraps the given function in a selector function which descends recursively into nested named tuples or arrays. If this functionality already exists somewhere and I don't know about it, please let me know!

I am also open to renaming things...