### PR TITLE
add setproperties for Param

### DIFF
--- a/src/param.jl
+++ b/src/param.jl
@@ -10,6 +10,11 @@ constructor that accepts a `NamedTuple`. It must have a `val` property, and shou
 """
 abstract type AbstractParam{T} <: AbstractNumbers.AbstractNumber{T} end
 
+function ConstructionBase.setproperties(p::P, patch::NamedTuple) where P <: AbstractParam
+    fields = ConstructionBase.setproperties(parent(p), patch)
+    P.name.wrapper(fields)
+end
+
 @inline withunits(m, args...) = map(p -> withunits(p, args...), params(m))
 @inline function withunits(p::AbstractParam, fn::Symbol=:val)
     _applyunits(*, getproperty(p, fn), get(p, :units, nothing))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,11 +1,20 @@
 using Aqua,
       DataFrames,
       ModelParameters,
+      Setfield,
       StaticArrays,
       Test,
       Unitful
 
 import BenchmarkTools
+
+@testset "param setproperties" begin
+    param = Param(1; a=2.0, b="3", c='4')
+    @set! param.val = 2
+    @test param.val == 2
+    @set! param.a = "99"
+    @test param.a == "99"
+end
 
 @testset "param math" begin
     # We don't have to test everything, that is for AbstractNumbers.jl


### PR DESCRIPTION
@lazarusA this should fix the problem you had setting `Param` fields with Setfield.jl in #34 

```julia
julia> p = Param(2.0, units = "k", bounds = (1, 2))
Param{Float64, NamedTuple{(:val, :units, :bounds), Tuple{Float64, String, Tuple{Int64, Int64}}}}((val = 2.0, units = "k", bounds = (1, 2)))

julia> @set p.val = 1
Param{Int64, NamedTuple{(:val, :units, :bounds), Tuple{Int64, String, Tuple{Int64, Int64}}}}((val = 1, units = "k", bounds = (1, 2)))
```