### PR TITLE
fix Tables.rows and test

### DIFF
--- a/src/model.jl
+++ b/src/model.jl
@@ -309,7 +309,7 @@ function _groupparams(m, cols::Symbol...)
     col = first(cols)
     names = map(Symbol, Tables.getcolumn(Tables.columns(m), col))
     groupnames = Tuple(unique(names))
-    return NamedTuple{groupnames}(Tuple(_groupparams(filter(x -> Symbol(x[col]) == n, Tables.rows(m)), Base.tail(cols)...) for n in groupnames))
+    return NamedTuple{groupnames}(Tuple(_groupparams(filter(x -> Symbol(x[col]) == n, collect(Tables.rows(m))), Base.tail(cols)...) for n in groupnames))
 end
 """
     mapflat(f, collection; maptype::Type=Union{NamedTuple,Tuple,AbstractArray})

--- a/src/model.jl
+++ b/src/model.jl
@@ -163,10 +163,10 @@ _keys(params::Tuple{}, m::AbstractModel) = ()
     end
 end
 
-function Base.show(io::IO, ::MIME"text/plain", m::AbstractModel)
-    show(typeof(m))
+function Base.show(io::IO, mime::MIME"text/plain", m::AbstractModel)
+    show(io, mime, typeof(m))
     println(io, " with parent object of type: \n")
-    show(typeof(parent(m)))
+    show(io, mime, typeof(parent(m)))
     println(io, "\n\n")
     printparams(io::IO, m)
 end

--- a/src/tables.jl
+++ b/src/tables.jl
@@ -14,9 +14,3 @@ Tables.getcolumn(m::AbstractModel, nm::Symbol) = collect(getindex(m, nm))
 Tables.getcolumn(m::AbstractModel, i::Int) = collect(getindex(m, i))
 Tables.getcolumn(m::AbstractModel, ::Type{T}, col::Int, nm::Symbol) where T = 
     collect(getindex(m, nm))
-
-# As rows
-Tables.rowaccess(::Type{<:AbstractModel}) = true
-# Vector of NamedTuple already has a row interface defined,
-# so we take a shortcut and return that.
-Tables.rows(m::AbstractModel) = [nt for nt in map((p,typ,name) -> merge((component=typ,fieldname=name), parent(p)), params(m), paramparenttypes(m), paramfieldnames(m))]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,8 +5,6 @@ using Aqua,
       StaticArrays,
       Test,
       Unitful
-p = Param(2.0, units = "k", bounds = (1, 2))
-@set p.val = 1
 
 import BenchmarkTools
 
@@ -83,6 +81,17 @@ end
     @test m[:val] == (2.0, 4.0, 6.0, 8.0, 10.0, 12.0, 198, 200.0)
     m[:newfield] = ntuple(x -> x, 8)
     @test m[:newfield] == ntuple(x -> x, 8)
+end
+
+@testset "show" begin
+    m = Model(s1)
+    sh = sprint(show, MIME"text/plain"(), m)
+    @test occursin("Model with parent", sh)
+    @test occursin("S1", sh)
+    @test occursin("Param", sh)
+    @test occursin("┌──────", sh)
+    @test occursin("component", sh)
+    @test occursin("100.0", sh)
 end
 
 @testset "strip params from model" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,8 @@ using Aqua,
       StaticArrays,
       Test,
       Unitful
+p = Param(2.0, units = "k", bounds = (1, 2))
+@set p.val = 1
 
 import BenchmarkTools
 
@@ -101,6 +103,9 @@ end
         Union{Float64,Int64},
         Union{Nothing,Tuple{Float64,Float64}},
     )
+    @test Tables.rows(m) isa Tables.RowIterator
+    @test Tables.columns(m) isa Model
+
     df = DataFrame(m)
     @test all(df.component .== m[:component])
     @test all(df.fieldname .== m[:fieldname])


### PR DESCRIPTION
@briochemc this should fix the Tables interface for `Tables.rows` If you can try it out in Pluto.jl that would be a help.

@bgroenks96 your `Tables.rows` implementation doesn't follow the Tables.jl interface apparently. Now we have to call `collect` on the output in your grouping function (we dont actually have to define `rows` either, Tables.jl does it for us)