### PR TITLE
allow more Param types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,6 @@ jobs:
       fail-fast: true
       matrix:
         version:
-          - '1.3'
           - '1.5'
           - 'nightly'
         os:

--- a/InteractModels/Project.toml
+++ b/InteractModels/Project.toml
@@ -12,7 +12,7 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 Interact = "0.10"
 ModelParameters = "0.3"
 Reexport = "0.2"
-julia = "1"
+julia = "1.5"
 
 [extras]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"

--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,7 @@ ConstructionBaseExtras = "0.1"
 PrettyTables = "0.8, 0.9, 0.10, 0.11, 0.12, 1"
 Setfield = "0.6, 0.7"
 Tables = "1"
-julia = "1"
+julia = "1.5"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"

--- a/src/ModelParameters.jl
+++ b/src/ModelParameters.jl
@@ -14,6 +14,8 @@ import AbstractNumbers,
        Tables 
 
 using Setfield
+
+using Base: tail
       
 export AbstractModel, Model, StaticModel
 

--- a/src/tables.jl
+++ b/src/tables.jl
@@ -10,7 +10,7 @@ _columntypes(m) = map(k -> Union{map(typeof, getindex(m, k))...}, keys(m))
 # As Columns
 Tables.columnaccess(::Type{<:AbstractModel}) = true
 Tables.columns(m::AbstractModel) = m
-Tables.getcolumn(m::AbstractModel, nm::Symbol) = collect(getindex(m, nm))
-Tables.getcolumn(m::AbstractModel, i::Int) = collect(getindex(m, i))
-Tables.getcolumn(m::AbstractModel, ::Type{T}, col::Int, nm::Symbol) where T = 
-    collect(getindex(m, nm))
+Tables.getcolumn(m::AbstractModel, nm::Symbol; kw...) = collect(getindex(m, nm; kw...))
+Tables.getcolumn(m::AbstractModel, i::Int; kw...) = collect(getindex(m, i; kw...))
+Tables.getcolumn(m::AbstractModel, ::Type{T}, col::Int, nm::Symbol; kw...) where T = 
+    collect(getindex(m, nm; kw...))


### PR DESCRIPTION
@briochemc this PR addes `select` keywords everywhere so that we can filter by other wrapper types - e.g. `AbstractParam`. (and `ignore` for the case there are types in your object that don't reconstruct, but that's a minor detail)

@bgroenks96 you might want to have a look at this and give some feedback. We will need to changing the grouping as well to not always use `Param`.

But, from the new tests, this is the kind of this it adds with `select`:

```julia
struct FreeParam{T,P<:NamedTuple} <: AbstractParam{T}
    parent::P
end
FreeParam(nt::NT) where {NT<:NamedTuple} = begin
    ModelParameters._checkhasval(nt)
    FreeParam{typeof(nt.val),NT}(nt)
end
FreeParam(val; kwargs...) = FreeParam((; val=val, kwargs...))
FreeParam(; kwargs...) = FreeParam((; kwargs...))

sf = S2(
    FreeParam(99),
    FreeParam(7),
    Param(100.0; bounds=(50.0, 150.0))
)
params(sf; select=FreeParam) == (FreeParam(99), FreeParam(7))
m = Model(sf)
m[:val, select=Param] == (100.0,)
getindex(m, :val; select=FreeParam) == (99, 7)
m[:bounds, select=FreeParam] = ((1, 100), (1, 10)) 
m[:bounds] == ((1, 100), (1, 10), (50.0, 150.0))
```

Probably we want a `@param MyParam` macro to define all those constructors automatically