### PR TITLE
Improve indexing to support table behavior

### DIFF
--- a/src/model.jl
+++ b/src/model.jl
@@ -128,13 +128,13 @@ Base.first(m::AbstractModel) = first(params(m))
 Base.last(m::AbstractModel) = last(params(m))
 Base.firstindex(m::AbstractModel) = 1
 Base.lastindex(m::AbstractModel) = length(params(m))
-Base.iterate(m::AbstractModel) = (first(params(m)), 1)
+Base.iterate(m::AbstractModel) = (first(params(m)), 2)
 Base.iterate(m::AbstractModel, s) = s > length(m) ? nothing : (params(m)[s], s + 1)
 Base.eachcol(m::AbstractModel) = (m[col] for col in keys(m))
 Base.eachrow(m::AbstractModel) = m
 
 # Vector methods
-Base.collect(m::AbstractModel) = collect(m.val)
+Base.collect(m::AbstractModel) = collect(m[:val])
 Base.vec(m::AbstractModel) = collect(m)
 Base.Array(m::AbstractModel) = vec(m)
 
@@ -200,7 +200,9 @@ end
 @inline Base.setindex(m::AbstractModel, xs, i) = Base.setindex(m, xs, i, :)
 @inline Base.setindex(m::AbstractModel, xs, i, col::Symbol) = Base.setindex(m, xs, i, Val{col})
 @inline Base.setindex(m::AbstractModel, xs, i, ::Type{Val{col}}) where col = Base.setindex(m, xs, collect(i), Val{col})
-@inline Base.setindex(m::AbstractModel, xs, i::Integer, ::Type{Val{col}}) where col = Base.setindex(m, xs, [i], Val{col})
+@inline Base.setindex(m::AbstractModel, xs, i, ::Colon) = Base.setindex(m, xs, collect(i), filter(!_isreserved, keys(m)))
+@inline Base.setindex(m::AbstractModel, xs, i::Integer, ::Colon) = Base.setindex(m, xs, i, filter(!_isreserved, keys(m)))
+@inline Base.setindex(m::AbstractModel, xs, i::Integer, ::Type{Val{col}}) where col = _setindex(m, xs, i, Val{col})
 @inline function Base.setindex(m::AbstractModel, xs, i, cols::Union{Tuple,AbstractVector})
     for col in cols
         m = Base.setindex(m, Tables.getcolumn(xs, col), i, Val{col})

--- a/src/model.jl
+++ b/src/model.jl
@@ -180,7 +180,7 @@ end
     newparams = map(params(obj), xs) do p, x
         Param((; parent(p)..., col => x))
     end
-    Flatten.reconstruct(obj, newparams, SELECT, IGNORE)
+    return Flatten.reconstruct(obj, newparams, SELECT, IGNORE)
 end
 
 # Indexing interface
@@ -279,7 +279,7 @@ end
 A wrapper type for any model containing [`Param`](@ref) parameters - essentially marking 
 that a custom struct or Tuple holds `Param` fields.
 
-This allows you to index into the model as if it is a linear lisat of parameters, or named 
+This allows you to index into the model as if it is a linear list of parameters, or named 
 columns of values and paramiter metadata. You can treat it as an iterable, or use the 
 Tables.jl interface to save or update the model to/from csv, a `DataFrame` or any source 
 that implements the Tables.jl interface.

--- a/src/model.jl
+++ b/src/model.jl
@@ -235,8 +235,8 @@ end
 Updates the `val` field of `Param`s at rows selected by `rule` in `obj` with the values in `xs`. Type stable and
 allocation free when all rows are selected (i.e. `rule=nothing`).
 """
-update(obj, xs::Union{AbstractVector,Tuple}, rule=nothing) = _setindex(obj, xs, _indices(obj, rule), Val{:val})
-update(m::AbstractModel, xs::Union{AbstractVector,Tuple}, rule=nothing) = Base.setindex(m, xs, _indices(m, rule), Val{:val})
+@inline update(obj, xs::Union{AbstractVector,Tuple}, rule=nothing) = _setindex(obj, xs, _indices(obj, rule), Val{:val})
+@inline update(m::AbstractModel, xs::Union{AbstractVector,Tuple}, rule=nothing) = Base.setindex(m, xs, _indices(m, rule), Val{:val})
 # Update (table)
 """
     update(m::AbstractModel, table, rule=nothing)
@@ -244,14 +244,14 @@ update(m::AbstractModel, xs::Union{AbstractVector,Tuple}, rule=nothing) = Base.s
 Updates the columns of `Param`s at rows selected by `rule` in `m` with the values in `table`, which must implement
 the `Tables.jl` interface.
 """
-update(m::AbstractModel, table, rule=nothing) = Base.setindex(m, table, _indices(m, rule), filter(!_isreserved, Tables.columnnames(table)))
+@inline update(m::AbstractModel, table, rule=nothing) = Base.setindex(m, table, _indices(m, rule), filter(!_isreserved, Tables.columnnames(table)))
 # Update helpers
 """
     update!(m::AbstractModel, xs, rule=nothing)
 
 Mutating version of `update` which sets the parent of `m` to the updated value.
 """
-update!(m::AbstractModel, xs, rule=nothing) = setparent!(m, parent(update(m, xs, rule)))
+@inline update!(m::AbstractModel, xs, rule=nothing) = setparent!(m, parent(update(m, xs, rule)))
 """
     update(f, m::AbstractModel, rule=nothing)
     update!(f, m::AbstractModel, rule=nothing)

--- a/src/model.jl
+++ b/src/model.jl
@@ -225,15 +225,15 @@ end
 @inline Base.setindex!(m::AbstractModel, xs, i, col) = setparent!(m, parent(Base.setindex(m, xs, i, col)))
 
 # helper function for evaluating indexing predicates
-_indices(m, rule) = findall(map(rule, map((c, n, p) -> setparent(p, (; parent(p)..., :component => c, :fieldname => n)), paramcomponents(m), paramfieldnames(m), params(m))))
-_indices(::Any, ::Nothing) = Colon()
+@inline _indices(m, rule) = findall(map(rule, map((c, n, p) -> setparent(p, (; parent(p)..., :component => c, :fieldname => n)), paramcomponents(m), paramfieldnames(m), params(m))))
+@inline _indices(::Any, ::Nothing) = Colon()
 
 # Update (value)
 """
     update(obj, xs::Union{AbstractVector,Tuple}, rule=nothing)
 
-Updates the `val` field of `Param`s at `idx` in `obj` with the values in `xs`. Type stable and
-allocation free when `idx=:`.
+Updates the `val` field of `Param`s at rows selected by `rule` in `obj` with the values in `xs`. Type stable and
+allocation free when all rows are selected (i.e. `rule=nothing`).
 """
 update(obj, xs::Union{AbstractVector,Tuple}, rule=nothing) = _setindex(obj, xs, _indices(obj, rule), Val{:val})
 update(m::AbstractModel, xs::Union{AbstractVector,Tuple}, rule=nothing) = Base.setindex(m, xs, _indices(m, rule), Val{:val})
@@ -241,7 +241,7 @@ update(m::AbstractModel, xs::Union{AbstractVector,Tuple}, rule=nothing) = Base.s
 """
     update(m::AbstractModel, table, rule=nothing)
 
-Updates the columns of `Param`s at rows `idx` in `m` with the values in `table`, which must implement
+Updates the columns of `Param`s at rows selected by `rule` in `m` with the values in `table`, which must implement
 the `Tables.jl` interface.
 """
 update(m::AbstractModel, table, rule=nothing) = Base.setindex(m, table, _indices(m, rule), filter(!_isreserved, Tables.columnnames(table)))

--- a/src/model.jl
+++ b/src/model.jl
@@ -269,7 +269,7 @@ function update(f, m::AbstractModel, rule=nothing)
     astable(xs) = Tables.columns(xs)
     ps = params(m)
     idxs = _indices(m, rule)
-    xs = astable(reduce(vcat, map(f, ps[idxs])))
+    xs = astable(collect(map(f, ps[idxs])))
     return Base.setindex(m, xs, idxs, Tables.columnnames(xs))
 end
 

--- a/src/model.jl
+++ b/src/model.jl
@@ -205,10 +205,9 @@ end
 @inline Base.setindex(m::AbstractModel, xs, i::Integer, ::Colon) = Base.setindex(m, xs, i, filter(!_isreserved, keys(m)))
 @inline Base.setindex(m::AbstractModel, xs, i::Integer, ::Type{Val{col}}) where col = _setindex(m, xs, i, Val{col})
 @inline function Base.setindex(m::AbstractModel, xs, i::RowIndexer, cols::Union{Tuple,AbstractVector})
-    for col in cols
-        m = Base.setindex(m, Tables.getcolumn(xs, col), i, Val{col})
+    return foldl(cols; init=m) do m, col
+        Base.setindex(m, Tables.getcolumn(xs, col), i, col)
     end
-    return m
 end
 @inline function Base.setindex(m::AbstractModel, xs, i::AbstractVector{<:Integer}, ::Type{Val{col}}) where col
     @assert !_isreserved(col) "column name :$col is reserved and cannot be modified"

--- a/src/param.jl
+++ b/src/param.jl
@@ -87,7 +87,6 @@ Base.parent(p::Param) = getfield(p, :parent)
 # Methods for objects that hold params
 params(x) = Flatten.flatten(x, SELECT, IGNORE)
 stripparams(x) = hasparam(x) ? Flatten.reconstruct(x, withunits(x), SELECT, IGNORE) : x
-
 # Utils
 hasparam(obj) = length(params(obj)) > 0
 

--- a/src/param.jl
+++ b/src/param.jl
@@ -80,12 +80,13 @@ end
 Param(val; kwargs...) = Param((; val=val, kwargs...))
 Param(; kwargs...) = Param((; kwargs...))
 
+setparent(::P, newparent) where P<:AbstractParam = P.name.wrapper(newparent)
+
 Base.parent(p::Param) = getfield(p, :parent)
 
 # Methods for objects that hold params
 params(x) = Flatten.flatten(x, SELECT, IGNORE)
 stripparams(x) = hasparam(x) ? Flatten.reconstruct(x, withunits(x), SELECT, IGNORE) : x
-
 
 # Utils
 hasparam(obj) = length(params(obj)) > 0

--- a/src/param.jl
+++ b/src/param.jl
@@ -80,7 +80,7 @@ end
 Param(val; kwargs...) = Param((; val=val, kwargs...))
 Param(; kwargs...) = Param((; kwargs...))
 
-setparent(::P, newparent) where P<:AbstractParam = P.name.wrapper(newparent)
+setparent(::P, newparent) where P<:AbstractParam = ConstructionBase.constructorof(P)(newparent)
 
 Base.parent(p::Param) = getfield(p, :parent)
 

--- a/src/param.jl
+++ b/src/param.jl
@@ -42,6 +42,7 @@ Base.values(p::AbstractParam) = values(parent(p))
 @inline Base.getproperty(p::AbstractParam, x::Symbol) = getproperty(parent(p), x)
 @inline Base.get(p::AbstractParam, key::Symbol, default) = get(parent(p), key, default)
 @inline Base.getindex(p::AbstractParam, i) = getindex(parent(p), i)
+@inline Base.getindex(p::AbstractParam, i::Integer) = getindex(parent(p), i)
 
 
 # AbstractNumber interface

--- a/src/tables.jl
+++ b/src/tables.jl
@@ -12,5 +12,4 @@ Tables.columnaccess(::Type{<:AbstractModel}) = true
 Tables.columns(m::AbstractModel) = m
 Tables.getcolumn(m::AbstractModel, nm::Symbol) = collect(getindex(m, nm))
 Tables.getcolumn(m::AbstractModel, i::Int) = collect(getindex(m, i))
-Tables.getcolumn(m::AbstractModel, ::Type{T}, col::Int, nm::Symbol) where T = 
-    collect(getindex(m, nm))
+Tables.getcolumn(m::AbstractModel, ::Type{T}, col::Int, nm::Symbol) where T = collect(getindex(m, nm))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -226,8 +226,11 @@ end
     ps = collect(m[:val]).*2.0
     new_s2 = @inferred update(s2, ps)
     @test all(Model(new_s2)[:val] .== ps)
-    b = BenchmarkTools.@benchmark update($s2, $ps)
-    @test b.allocs == 0
+    if VERSION >= v"1.6"
+        # will allocate on Julia versions <1.6
+        b = BenchmarkTools.@benchmark update($s2, $ps)
+        @test b.allocs == 0
+    end
 end
 
 @testset "parameter grouping" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -81,6 +81,13 @@ end
                        (5.0, 15.0), (5.0, 15.0), nothing, (50.0, 150.0))
 end
 
+@testset "iterables interface" begin
+    m = Model(s1)
+    @test tuple(m...) == tuple((m[i] for i in 1:length(m))...)
+    @test collect(eachrow(m)) == [m[i] for i in 1:length(m)]
+    @test collect(eachcol(m)) == [m[col] for col in keys(m)]
+end
+
 @testset "setindex updates and adds param fields" begin
     m = Model(s1)
     # set all rows
@@ -89,9 +96,12 @@ end
     # set single row
     m[1,:val] = m[1,:val]*2
     @test m[1,:val] == 4.0
+    m[1] = m[2]
+    @test m[1] == m[2]
     # set multiple rows
+    m = Model(s1)
     m[[1,3,5],:val] = m[[1,3,5],:val].*2
-    @test m[[1,3,5],:val] == (8.0, 12.0, 20.0)
+    @test m[[1,3,5],:val] == (2.0, 6.0, 10.0)
     # add new column
     m[:newfield] = ntuple(x -> x, 8)
     @test m[:newfield] == ntuple(x -> x, 8)
@@ -101,6 +111,10 @@ end
     @test m[:,:val] == m[:val]
     @test m[1,:] == m[1]
     @test m[:,:] == m
+    # test extra immutable cases
+    m = Model(s1)
+    @test Base.setindex(m, m[:val].*2, :val)[:val] == m[:val].*2
+    @test Base.setindex(m, m[2], 1)[1] == m[2]
 end
 
 @testset "show" begin


### PR DESCRIPTION
This is a major overhaul of the model interface to better support Table-like indexing behavior, most importantly through `setindex`.

The basic idea is that `AbstractModel`s should allow Cartesian indexing, i.e. `m[i,j]` for both `setindex!` as well as `getindex` in order to really act like a table.

This PR refactors the existing implementations of `getindex` and `setindex!` to accomplish this, and in the process, expands the functionality of `setindex!` (and `Base.setindex` for the immutable case) to permit row indices.

The implementations of `update`/`update!` are simplified to be simple wrappers around `setindex`. In addition, `update` now provides an additional dispatch which permits the application of filtering rules to generate row indices via `do` syntax:

```julia
updated_m = update(m, p -> p.somefield == somevalue) do p
    # generate values here;
    # returning a scalar will apply the new values to the :val field;
    # returning a row vector, NamedTuple, or any Tables.jl compatible type will update all columns in the table.
    p.val * 2.0
end
```
This allows the user to apply filters to only update subsets of parameters. This is also possible via `setindex!` using row indices:

```julia
mask = map(p -> p.somefield == somevalue, params(m))
m[mask, :val] = x # x must match in size
```
~This is a draft PR at the moment. More clean up needs to be done and docstrings added at the minimum. There are also some behavioral issues that need to  be addressed, like how to handle broadcasting.~

Current limitations:
- Multi-column indexing for `getindex` is not supported, since it's not clear what the return value should be (named tuples?). It is supported by `setindex`, however.
- `getindex`/`setindex` on subsets of rows are not in general type stable or allocation free. I think this is acceptable for now given the likely use cases.

Resolves #41 
Resolves #21