### PR TITLE
Remove ConstructionBaseExtras as direct dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: codecov/codecov-action@v1
         with:
           file: lcov.info
-          fail_ci_if_error: true
+          fail_ci_if_error: false
   docs:
     name: Documentation
     runs-on: ubuntu-latest

--- a/InteractModels/Project.toml
+++ b/InteractModels/Project.toml
@@ -1,7 +1,7 @@
 name = "InteractModels"
 uuid = "546b680c-e627-4c75-86f8-7ef2c81e5d51"
 authors = ["Rafael Schouten <rafaelschouten@gmail.com> and contributors"]
-version = "0.4.1"
+version = "0.4.2"
 
 [deps]
 Interact = "c601a237-2ae4-5e1e-952c-7a85b0c7eef1"
@@ -10,7 +10,7 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [compat]
 Interact = "0.10"
-ModelParameters = "0.3"
+ModelParameters = "0.3, 0.4"
 Reexport = "0.2, 1"
 julia = "1"
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,12 +1,11 @@
 name = "ModelParameters"
 uuid = "4744a3fa-6c31-4707-899e-a3298e4618ad"
 authors = ["Rafael Schouten <rafaelschouten@gmail.com> and contributors"]
-version = "0.3.7"
+version = "0.4.0"
 
 [deps]
 AbstractNumbers = "85c772de-338a-5e7f-b815-41e76c26ac1f"
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
-ConstructionBaseExtras = "914cd950-b775-4282-9f32-54fc4544c321"
 Flatten = "4c728ea3-d9ee-5c9a-9642-b6f7d7dc04fa"
 PrettyTables = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
 Setfield = "efcf1570-3423-57d1-acb7-fd33fddbac46"
@@ -15,7 +14,6 @@ Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 [compat]
 AbstractNumbers = "0.2.1"
 ConstructionBase = "1"
-ConstructionBaseExtras = "0.1"
 Flatten = "0.4"
 PrettyTables = "0.8, 0.9, 0.10, 0.11, 0.12, 1, 2"
 Setfield = "0.6, 0.7, 0.8, 1"
@@ -25,10 +23,11 @@ julia = "1"
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+ConstructionBaseExtras = "914cd950-b775-4282-9f32-54fc4544c321"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [targets]
-test = ["Aqua", "BenchmarkTools", "DataFrames", "StaticArrays", "Test", "Unitful"]
+test = ["Aqua", "BenchmarkTools", "DataFrames", "StaticArrays", "Test", "Unitful", "ConstructionBaseExtras"]

--- a/Project.toml
+++ b/Project.toml
@@ -30,4 +30,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [targets]
-test = ["Aqua", "BenchmarkTools", "DataFrames", "StaticArrays", "Test", "Unitful", "ConstructionBaseExtras"]
+test = ["Aqua", "BenchmarkTools", "ConstructionBaseExtras", "DataFrames", "StaticArrays", "Test", "Unitful"]

--- a/README.md
+++ b/README.md
@@ -186,3 +186,10 @@ and BangBang.jl.
 [ConstructionBaseExtras.jl](https://github.com/JuliaObjects/ConstructionBaseExtras.jl) also
 exists to add support to common packages, such as StaticArrays.jl arrays. Import it if you 
 need StaticArrays support, or open an issue to add support to additional packages.
+
+**Note: Breaking change in 0.4.0**
+With the introduction of weak extensions in Julia 1.9, ConstructionBase.jl and ConstructionBaseExtras.jl
+should not be loaded at the same time (see [this issue](https://github.com/rafaqz/ModelParameters.jl/issues/52)). 
+ModelParameters.jl has dropped the direct dependency on ConstructionBase.jl in version 0.4.0.
+Users that employ Julia versions <1.9 are advised to load ConstructionBaseExtras.jl themselves if StaticArrays.jl 
+support is needed.

--- a/src/ModelParameters.jl
+++ b/src/ModelParameters.jl
@@ -8,13 +8,12 @@ end ModelParameters
 
 import AbstractNumbers,
        ConstructionBase,
-       ConstructionBaseExtras,
        Flatten,
-       PrettyTables, 
-       Tables 
+       PrettyTables,
+       Tables
 
 using Setfield
-      
+
 export AbstractModel, Model, StaticModel
 
 export AbstractParam, Param

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,6 +6,10 @@ using Aqua,
       Test,
       Unitful
 
+if !isdefined(Base, :get_extension) #ensures test compatibility for Julia versions <1.9
+    using ConstructionBaseExtras
+end
+
 import ModelParameters: component
 import BenchmarkTools
 
@@ -155,14 +159,14 @@ end
     @test m[:units] == (nothing, u"s", u"K", u"m", nothing, nothing, u"m*s^2", nothing)
     # Values have units now
     @test withunits(m) == (1.0, 2.0u"s", 3.0u"K", 4.0u"m", 5.0, 6.0, 7.0u"m*s^2", 8.0)
-    @test withunits(m, :bounds) == 
-        ((5.0, 15.0), (5.0, 15.0) .* u"s", (5.0, 15.0) .* u"K", nothing, 
+    @test withunits(m, :bounds) ==
+        ((5.0, 15.0), (5.0, 15.0) .* u"s", (5.0, 15.0) .* u"K", nothing,
          (5.0, 15.0), nothing, (50.0, 150.0) .* u"m*s^2", nothing)
     @test stripunits(m, (1.0, 2.0u"s", 3.0u"K", 4.0u"m", 5.0, 6.0, 7.0u"m*s^2", 8.0)) ==
         (1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0)
-    @test stripunits(m, ((5.0, 15.0), (5.0, 15.0) .* u"s", (5.0, 15.0) .* u"K", nothing, 
+    @test stripunits(m, ((5.0, 15.0), (5.0, 15.0) .* u"s", (5.0, 15.0) .* u"K", nothing,
                          (5.0, 15.0), nothing, (50.0, 150.0) .* u"m*s^2", nothing)) ==
-                        ((5.0, 15.0), (5.0, 15.0), (5.0, 15.0), nothing, 
+                        ((5.0, 15.0), (5.0, 15.0), (5.0, 15.0), nothing,
                          (5.0, 15.0), nothing, (50.0, 150.0), nothing)
 end
 


### PR DESCRIPTION
Addresses #52

- Removed ConstructionBaseExtras.jl as direct dependency.
- Added note to readme file.
- Changed version number to 0.4.0
- Kept tests running on Julia <1.9 by adding ConstructionBaseExtras as a test dependency that gets loaded if on those Julia versions.
- Tested on both Julia 1.9.0-rc1 and Julia 1.8.2 locally and all passes.