### PR TITLE
add Const wrappers

### DIFF
--- a/ext/ModelParametersMakieExt/makiemodel.jl
+++ b/ext/ModelParametersMakieExt/makiemodel.jl
@@ -64,11 +64,11 @@ function param_sliders!(fig, model::AbstractModel; layout=fig, ncolumns, slider_
     else
         model1[:fieldname]
     end
-    values = withunits(model1)
+    values = paramswithunits(model1)
     ranges = if haskey(model1, :range)
-        withunits(model1, :range)
+        paramswithunits(model1, :range)
     elseif haskey(model1, :bounds)
-        _makerange.(withunits(model1, :bounds), values)
+        _makerange.(paramswithunits(model1, :bounds), values)
     else
         _makerange.(Ref(nothing), values)
     end

--- a/src/ModelParameters.jl
+++ b/src/ModelParameters.jl
@@ -16,9 +16,9 @@ using Setfield
 
 export AbstractModel, Model, StaticModel, MakieModel
 
-export AbstractParam, Param, RealParam
+export AbstractParam, Param, RealParam, Const, RealConst
 
-export params, printparams, stripparams, update, update!, withunits, stripunits, groupparams, mapflat
+export params, constants, printparams, strip, update, update!, withunits, paramswithunits, constantswithunits, stripunits, groupparams, mapflat
 
 include("interface.jl")
 include("param.jl")

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -2,26 +2,34 @@
     params(object)
     params(model::AbstractModel)
 
-Returns a tuple of all `Param`s in the model or arbitrary object.
+Returns a tuple of all `AbstractParam`s or `AbstractRealParam`s in the model, or arbitrary object.
 """
 function params end
+
+"""
+    constants(object)
+    constants(model::AbstractModel)
+
+Returns a tuple of all `Const`s in the model or arbitrary object.
+"""
+function constants end
 
 """
     printparams(object)
     printparams(io::IO, object)
 
-Prints a table of all `Param`s in the object, similar to what
-is printed in the repl for `AbstractModel`.
+Prints a table of all `AbstractParam`s or `AbstractRealParam`s in the object, 
+similar to what is printed in the repl for `AbstractModel`.
 """
 function printparams end
 
 """
-    stripparams(object)
+    strip(object)
 
-Strips all `AbstractParam` from an object, replacing them with the `val` 
-field, or a combination of `val` and `units` if a `units` field exists.
+Strips all `AbstractParam`, `AbstractConst` from an object, replacing them with 
+the `val` field, or a combination of `val` and `units` if a `units` field exists.
 """
-function stripparams end
+function strip end
 
 """
     update!(m::MutableModel, table)
@@ -40,34 +48,6 @@ Update the model from an object that implements the Tables.jl interface,
 returning a new, updated object.
 """
 function update end
-
-"""
-    withunits(object, [fieldname])
-    withunits(model::AbstractModel, [fieldname])
-    withunits(param::AbstractParam, [fieldname])
-
-Returns the field specifed by `fieldname` (by default `:val`) for a single `Param`, 
-or a tuple of the `Param`s in a `Model` or arbitrary object. 
-
-If there is a `units` field the returned value will be a combination of the specied field 
-and the `units` fields. 
-
-If there is no units field or a specific `Param`s `units` fields contains `nothing`, 
-the field value is returned unchanged.
-"""
-function withunits end
-
-"""
-    stripunits(model::AbstractModel, xs)
-    stripunits(param::AbstractParam, x)
-
-Returns the `x` or `xs` divided by their corresponding units field, if it exists.
-
-It there is no units field, and x has units, it will be returned with units! It
-you want to simply remove all units, using Unitful.ustrip.
-"""
-function stripunits end
-
 
 # Low-level, non-exported interface
 

--- a/src/model.jl
+++ b/src/model.jl
@@ -84,7 +84,7 @@ Base.parent(m::AbstractModel) = getfield(m, :parent)
 setparent(m::AbstractModel, newparent) = @set m.parent = newparent
 
 params(m::AbstractModel) = params(parent(m))
-stripparams(m::AbstractModel) = stripparams(parent(m))
+strip(m::AbstractModel) = strip(parent(m))
 function update(x::T, values) where {T<:AbstractModel}
     hasfield(T, :parent) || _updatenotdefined(T)
     setparent(x, update(parent(x), values))
@@ -92,8 +92,8 @@ end
 
 @noinline _update_methoderror(T) = error("Interface method `update` is not defined for $T")
 
-paramfieldnames(m) = Flatten.fieldnameflatten(parent(m), SELECT, IGNORE)
-paramparenttypes(m) = Flatten.metaflatten(parent(m), _fieldparentbasetype, SELECT, IGNORE)
+paramfieldnames(m) = Flatten.fieldnameflatten(parent(m), SELECTPARAM, IGNORE)
+paramparenttypes(m) = Flatten.metaflatten(parent(m), _fieldparentbasetype, SELECTPARAM, IGNORE)
 _fieldparentbasetype(T, ::Type{Val{N}}) where {N} = component(T)
 
 """
@@ -148,14 +148,14 @@ end
     newparams = map(params(obj), xs) do par, x
         rebuild(par, Setfield.set(parent(par), lens, x))
     end
-    Flatten.reconstruct(obj, newparams, SELECT, IGNORE)
+    return reconstructparam(obj, newparams)
 end
 @inline function _addindex(obj, xs::Tuple, nm::Symbol)
     lens = Setfield.ComposedLens(Setfield.PropertyLens{:parent}(), Setfield.PropertyLens{nm}())
     newparams = map(params(obj), xs) do par, x
         rebuild(par, (; parent(par)..., (nm => x,)...))
     end
-    Flatten.reconstruct(obj, newparams, SELECT, IGNORE)
+    return reconstructparams(obj, newparams)
 end
 
 _keys(params::Tuple, m::AbstractModel) = (:component, :fieldname, keys(first(params))...)
@@ -191,7 +191,7 @@ setparent!(m::AbstractModel, newparent) = setfield!(m, :parent, newparent)
 
 update!(m::AbstractModel, vals::AbstractVector{<:AllParams}) = update!(m, Tuple(vals))
 function update!(params::Tuple{<:AllParams,Vararg{AllParams}})
-    setparent!(m, Flatten.reconstruct(parent(m), params, SELECT, IGNORE))
+    setparent!(m, reconstructparams(parent(m), params))
 end
 function update!(m::AbstractModel, table)
     cols = (c for c in Tables.columnnames(table) if !(c in (:component, :fieldname)))
@@ -219,7 +219,7 @@ mutable struct Model <: AbstractModel
         if hasparam(parent)
             # Make sure all params have all the same keys.
             expandedpars = _expandkeys(params(parent))
-            parent = Flatten.reconstruct(parent, expandedpars, SELECT, IGNORE)
+            parent = reconstructparams(parent, expandedpars)
         else
             _noparamwarning()
         end
@@ -244,7 +244,7 @@ update(x, values) = _update(ModelParameters.params(x), x, values)
 @inline function _update(p::P, x, values::Union{<:AbstractVector,<:Tuple}) where {N,P<:NTuple{N,AllParams}}
     @assert length(values) == N "values length must match the number of parameters"
     newparams = _update_params(p, values)
-    Flatten.reconstruct(x, newparams, SELECT, IGNORE)
+    reconstructparams(x, newparams)
 end
 @inline function _update(p::P, x, table) where {N,P<:NTuple{N,AllParams}}
     @assert size(table, 1) == N "number of rows must match the number of parameters"
@@ -252,7 +252,7 @@ end
     newparams = map(p, tuple(1:N...)) do param, i
         Param(NamedTuple{keys(param)}(map(name -> Tables.getcolumn(table, name)[i], cols)))
     end
-    Flatten.reconstruct(x, newparams, SELECT, IGNORE)
+    return reconstructparams(x, newparams)
 end
 
 """
@@ -267,7 +267,7 @@ struct StaticModel{P} <: AbstractModel
         # Need at least 1 AbstractParam field to be a Model
         if hasparam(parent)
             expandedpars = _expandkeys(params(parent))
-            parent = Flatten.reconstruct(parent, expandedpars, SELECT, IGNORE)
+            reconstructparams(parent, expandedpars)
         else
             _noparamwarning()
         end
@@ -279,17 +279,20 @@ StaticModel(m::AbstractModel) = StaticModel(parent(m))
 
 # Model Utils
 
-_expandpars(x) = Flatten.reconstruct(parent, _expandkeys(parent), SELECT, IGNORE)
+_expandpars(x) = reconstructparams(parent, _expandkeys(parent))
 # Expand all Params to have the same keys, filling with `nothing`
 # This probably will allocate due to `union` returning `Vector`
 function _expandkeys(x)
     pars = params(x)
     allkeys = Tuple(union(map(keys, pars)...))
+    _expandkeys1(pars, Val{allkeys}())
+end
+Base.@assume_effects :foldable function _expandkeys1(pars, ::Val{Keys}) where Keys
     return map(pars) do par
-        vals = map(allkeys) do key
-            get(par, key, nothing)
+        vals = map(Keys) do key
+            hasproperty(par, key) ? par[key] : nothing
         end
-        rebuild(par, NamedTuple{allkeys}(vals))
+        rebuild(par, NamedTuple{Keys}(vals))
     end
 end
 
@@ -320,6 +323,7 @@ function _groupparams(m, cols::Symbol...)
     groupnames = Tuple(unique(names))
     return NamedTuple{groupnames}(Tuple(_groupparams(filter(x -> Symbol(x[col]) == n, collect(Tables.rows(m))), Base.tail(cols)...) for n in groupnames))
 end
+
 """
     mapflat(f, collection; maptype::Type=Union{NamedTuple,Tuple,AbstractArray})
 


### PR DESCRIPTION
Closes #66 

This PR adds `Const` wrappers to easily move between constant/forward parameters and variable parameters.

@bgroenks96 if you have some thoughts on this approach and if its useful. Ive used all the param code in `@eval` loops to ensure `Const` and `Param` are essentially identical.

Needs tests